### PR TITLE
Removing default cache time value for MVC template

### DIFF
--- a/generators/mvc/templates/manifest.dnn
+++ b/generators/mvc/templates/manifest.dnn
@@ -51,7 +51,7 @@
             <moduleDefinitions>
               <moduleDefinition>
                 <friendlyName><%= moduleName %></friendlyName>
-                <defaultCacheTime>60</defaultCacheTime>
+                <defaultCacheTime>0</defaultCacheTime>
                 <moduleControls>
                   <moduleControl>
                     <controlKey>


### PR DESCRIPTION
After some research with the MVC Module Pattern I have determined that the defaultCacheTime is something that should always be set to 0 otherwise the Controller will not operate correctly. This PR sets it to 0 so other developers will not be chasing down this caching issue.

Consider the following Scenarios:

**Scenario 1: 2 Action Methods 1 Controller**
The `HomeController` has 2 Action Methods:

* Index
* Edit

If a user navigates to the MVC Module's Index this response has now been added to the cache. When they navigate to edit **regardless** what shows in the browser URL it will pull the response from the cache and they will just see the Index Page.

This scenario flipped has the same logic where if the user navigates to Edit they will never be able to get to Index because the response is cached.

This also means the user will never be able to get a new response (see scenario 2 for detail).

This appears to be an intermittent issue at first because if you are logged in and you are in edit mode the cache doesn't apply to you.

**Scenario 2: 1 Action Method 1 Controller**

The `HomeController` has 1 Action Method: `Index`

If a user navigates to the MVC Module's Index the response is built and then cached. This is great if your data doesn't change as the user interacts with this page. If it does you will be in trouble. Until the cache is purged/expired the Index Action Method will **never** execute. This means if you have different data that returns based on different user interactions or as your database changes it will not update in the module.

Again in edit mode this doesn't appear since the cache doesn't work in edit mode.

--
TLDR: We have to set the `defaultCacheTime` to 0 otherwise the MVC Module will not work correctly