### PR TITLE
Updated gulpfile msbuild to use auto instead of 14.0

### DIFF
--- a/generators/gulp/build.js
+++ b/generators/gulp/build.js
@@ -36,7 +36,7 @@ gulp.task('assemblyInfo', function() {
 gulp.task('build', ['nuget', 'assemblyInfo'], function() {
   return gulp.src('./<%= moduleName %>.csproj').pipe(
     msbuild({
-      toolsVersion: 14.0,
+      toolsVersion: 'auto',
       targets: ['Clean', 'Build'],
       errorOnFail: true,
       stdout: true,


### PR DESCRIPTION
This fixes issues with using different versions of Visual Studio