### PR TITLE
[MVC] Added License.md and packages.config to the csproj template

### DIFF
--- a/generators/mvc/templates/_Project.csproj
+++ b/generators/mvc/templates/_Project.csproj
@@ -147,6 +147,8 @@
     <Content Include="Views\_ViewStart.cshtml" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="package.json" />
+    <Content Include="License.md" />
     <None Include="packages.config" />
     <Content Include="web.config" />
     <None Include="web.Debug.config">


### PR DESCRIPTION
Added missing files to the MVC csproj template

+ License.md
+ package.json

These files are included in the SPA template and not the MVC template

## Affected Version
[ ] SPA
[x] MVC

fixes: #23 