### PR TITLE
[MVC] Fixes Broken Settings Page

### DIFF
--- a/generators/mvc/templates/Views/Settings/Settings.cshtml
+++ b/generators/mvc/templates/Views/Settings/Settings.cshtml
@@ -1,4 +1,4 @@
-﻿@model <%= namespace %>.Modules.<%= moduleName %>.Models.Settings
+﻿@inherits DotNetNuke.Web.Mvc.Framework.DnnWebViewPage<<%= namespace %>.Modules.<%= moduleName %>.Models.Settings>
 
 @using System.Web.Mvc
 @using System.Web.Mvc.Html
@@ -8,11 +8,16 @@
 <fieldset>
     <div class="dnnFormItem">
         <div class="dnnLabel" style="position: relative;">
-            @Html.LabelFor(m => Model.CurrencyCulture, Dnn.LocalizeString("lblCurrencyCulture"), new { @class = "col-md-2 control-label" })
+            @Html.LabelFor(m => Model.Setting1, Dnn.LocalizeString("lblSetting1"), new { @class = "col-md-2 control-label" })
         </div>
-        @Html.DropDownListFor(m => Model.CurrencyCulture, 
-            new SelectList(Model.CurrencyCultureOptions, "Code", "Name", Model.CurrencyCultureOptions.First()))
+        @Html.DropDownListFor(m => Model.Setting1,
+            new SelectList(new[] { true, false }))
     </div>
-
+    <div class="dnnFormItem">
+        <div class="dnnLabel" style="position: relative;">
+            @Html.LabelFor(m => Model.Setting2, Dnn.LocalizeString("lblSetting2"), new { @class = "col-md-2 control-label" })
+        </div>
+        @Html.TextBoxFor(m => Model.Setting2)
+    </div>
 </fieldset>
 


### PR DESCRIPTION
Updates markup in the settings.cshtml to reference correct variables. The page now should work correctly if the resx is defined correctly;

**note**
I am not 100% sure if I got the correct syntax with the yeoman templating for line 1. I am nervous with the amount of `<` characters next to each other.

I think it would be useful to create a contributing guide or how to build and run locally

Fixes #25