### PR TITLE
Do not include _BuildScripts directory in install package

### DIFF
--- a/generators/gulp/dnn-package.js
+++ b/generators/gulp/dnn-package.js
@@ -47,7 +47,13 @@ gulp.task('packageInstall', ['build'], function() {
         '**/<%= namespace%>.<%= moduleName %>.dll',
         '**/<%= moduleName %>.dnn',
         '**/*.SqlDataProvider',
+        '!/**/gulpfile.js',
+        '!/**/{_BuildScripts,_BuildScripts/**}',
+        '!/**/{_Packages,_Packages/**}',
+        '!/**/{bin,bin/**}',
         '!/**/{obj,obj/**}',
+        '!/**/{packages,packages/**}',
+        '!/**/{node_modules,node_modules/**}',
         '!/**/{_PublishedWebsites,_PublishedWebsites/**}'
       ]),
       gulp

--- a/generators/gulp/dnn-package.js
+++ b/generators/gulp/dnn-package.js
@@ -27,6 +27,8 @@ gulp.task('packageInstall', ['build'], function() {
         '**/*.svg',
         '!/**/web.config',
         '!/**/gulpfile.js',
+        '!/**/{_BuildScripts,_BuildScripts/**}',
+        '!/**/{_Packages,_Packages/**}',
         '!/**/{bin,bin/**}',
         '!/**/{obj,obj/**}',
         '!/**/{packages,packages/**}',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
Fixes #54

## Description
Do not include _BuildScripts directory in the install package
